### PR TITLE
#97 - Simulation from extreme points of X0

### DIFF
--- a/models/ACC/ACC.jl
+++ b/models/ACC/ACC.jl
@@ -87,7 +87,7 @@ X₀ = Hyperrectangle(low=[90, 32, 0, 10, 30, 0], high=[110, 32.2, 0, 11, 30.2, 
 U₀ = Singleton([-1.0]); # gets overwritten
 
 # The system has 6 state variables and 1 control variable:
-vars_idx = Dict(:state_vars=>1:6, :input_vars=>[], :control_vars=>7)
+vars_idx = Dict(:state_vars=>1:6, :control_vars=>7)
 ivp = @ivp(x' = ACC!(x), dim: 7, x(0) ∈ X₀×U₀);
 
 # We will evaluate the controller which has 5 hidden layers.

--- a/models/Airplane/Airplane.jl
+++ b/models/Airplane/Airplane.jl
@@ -167,7 +167,7 @@ X₀ = overapproximate(X₀, Hyperrectangle)
 
 U₀ = rand(Hyperrectangle, dim=6) # ignored
 #prob = @ivp(x' = airplane!(x), dim: 18, x(0) ∈ X₀ × U₀);
-vars_idx = Dict(:state_vars=>1:12, :input_vars=>[], :control_vars=>13:18);
+vars_idx = Dict(:state_vars=>1:12, :control_vars=>13:18);
 period = 0.1
 
 #=

--- a/models/Sherlock-Benchmark-9-TORA/Sherlock-Benchmark-9-TORA.jl
+++ b/models/Sherlock-Benchmark-9-TORA/Sherlock-Benchmark-9-TORA.jl
@@ -69,7 +69,7 @@ safe_states = BallInf(zeros(2), 2.0);
 
 using DifferentialEquations, Plots
 
-simulations, controls = simulate(plant, T=20.0, trajectories=20);
+simulations, controls, inputs = simulate(plant, T=20.0, trajectories=20);
 
 #-
 

--- a/models/Single-Pendulum/Single-Pendulum.jl
+++ b/models/Single-Pendulum/Single-Pendulum.jl
@@ -40,7 +40,7 @@ end
 
 # define the initial-value problem
 X0 = Hyperrectangle([1.1, 0.1], [0.1, 0.1]);
-U0 = Universe(1)
+U0 = ZeroSet(1)
 
 ivp = @ivp(x' = single_pendulum!(x), dim: 3, x(0) ∈ X0 × U0);
 vars_idx = Dict(:state_vars=>1:2, :control_vars=>3);

--- a/models/Single-Pendulum/Single-Pendulum.jl
+++ b/models/Single-Pendulum/Single-Pendulum.jl
@@ -43,7 +43,7 @@ X0 = Hyperrectangle([1.1, 0.1], [0.1, 0.1]);
 U0 = Universe(1)
 
 ivp = @ivp(x' = single_pendulum!(x), dim: 3, x(0) ∈ X0 × U0);
-vars_idx = Dict(:state_vars=>1:2, :input_vars=>[], :control_vars=>3);
+vars_idx = Dict(:state_vars=>1:2, :control_vars=>3);
 period = 0.05
 
 prob = ControlledPlant(ivp, controller, vars_idx, period);

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -75,6 +75,6 @@ controller(cp::ControlledPlant) = cp.controller
 period(cp::ControlledPlant) = cp.period
 control_normalization(cp::ControlledPlant) = cp.normalization
 
-state_vars(cp::ControlledPlant) = get(cp.vars, :state_vars, nothing)
-input_vars(cp::ControlledPlant) = get(cp.vars, :input_vars, nothing)
-control_vars(cp::ControlledPlant) = get(cp.vars, :control_vars, nothing)
+state_vars(cp::ControlledPlant) = get(cp.vars, :state_vars, Int[])
+input_vars(cp::ControlledPlant) = get(cp.vars, :input_vars, Int[])
+control_vars(cp::ControlledPlant) = get(cp.vars, :control_vars, Int[])

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -37,18 +37,20 @@ function simulate(cp::AbstractNeuralNetworkControlProblem, args...; kwargs...)
     trajectories = get(kwargs, :trajectories, 10)
     inplace = get(kwargs, :inplace, true)
     normalization = control_normalization(cp)
+    include_vertices = get(kwargs, :include_vertices, false)
 
     t = tstart(time_span)
     iterations = ceil(Int, diam(time_span) / τ)
+
+    # sample initial states
+    states = sample(X₀, trajectories; include_vertices=include_vertices)
+    trajectories = length(states)
 
     # preallocate
     extended = Vector{Vector{Float64}}(undef, trajectories)
     simulations = Vector{EnsembleSolution}(undef, iterations)
     all_controls = Vector{Vector{Vector{Float64}}}(undef, iterations)
     all_inputs = Vector{Vector{Vector{Float64}}}(undef, iterations)
-
-    # sample initial states
-    states = sample(X₀, trajectories)
 
     @inbounds for i in 1:iterations
         # compute control inputs


### PR DESCRIPTION
Closes #97.

* The first commit is an unrelated fix.
* The second commit is the actual change. The not-so-nice aspect is that the number of trajectories gets larger than `trajectories`. That also complicates sampling from the vertices of the input set so I did not include that.
* The third commit is needed because we can only sample from a bounded set (see #102 for the explanation why we think that the set is unbounded).

![pendulum](https://user-images.githubusercontent.com/9656686/109224875-d372b880-77bc-11eb-8cf3-044d246fdae1.png)