### PR TITLE
#90 - More precise reach set at time point from Taylor model

### DIFF
--- a/src/setops.jl
+++ b/src/setops.jl
@@ -2,12 +2,12 @@
 # Projection operations
 # ========================================
 
-function _project_oa(X::AbstractLazyReachSet, vars)
+function _project_oa(X::AbstractLazyReachSet, vars, t)
     return Project(X, vars)
 end
 
-function _project_oa(X::AbstractTaylorModelReachSet, vars)
-    Z = overapproximate(X, Zonotope)
+function _project_oa(X::AbstractTaylorModelReachSet, vars, t)
+    Z = overapproximate(X, Zonotope, t)
     return project(Z, vars)
 end
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -140,7 +140,7 @@ function _solve(cp::ControlledPlant,
         ti += sampling_time
 
         X = sol(ti)
-        X₀ = _project_oa(X, st_vars) |> set
+        X₀ = _project_oa(X, st_vars, ti) |> set
         P₀ = isempty(in_vars) ? X₀ : X₀ × W₀
 
         U₀ = forward_network(solver, network, X₀)


### PR DESCRIPTION
Closes #90.

There is definitely an improvement but it is smaller than I had hoped.

SinglePendulum, old vs. new, two steps and ten steps each.

![1_old](https://user-images.githubusercontent.com/9656686/110082646-eb82a300-7d8d-11eb-8803-b820d2434b94.png)
![1_new](https://user-images.githubusercontent.com/9656686/110082651-ede4fd00-7d8d-11eb-8f3d-d5910f01215d.png)
![1_both](https://user-images.githubusercontent.com/9656686/110083074-82e7f600-7d8e-11eb-88fa-62a2f81b625f.png)

![2_old](https://user-images.githubusercontent.com/9656686/110082699-ffc6a000-7d8d-11eb-8a4c-d373b4ca76c5.png)
![2_new](https://user-images.githubusercontent.com/9656686/110082703-01906380-7d8e-11eb-8dbd-a1e9d0d352d6.png)
![2_both](https://user-images.githubusercontent.com/9656686/110083090-88ddd700-7d8e-11eb-98c8-c5dc053c15ec.png)