### PR TITLE
Revise SimulationSolution

### DIFF
--- a/models/Sherlock-Benchmark-9-TORA/Sherlock-Benchmark-9-TORA.jl
+++ b/models/Sherlock-Benchmark-9-TORA/Sherlock-Benchmark-9-TORA.jl
@@ -75,28 +75,46 @@ sim = simulate(plant, T=20.0, trajectories=20);
 
 fig = plot(xlab="x₁", ylab="x₂")
 plot!(fig, safe_states, color=:white, linecolor=:black, lw=5.0)
+xl = xlims()
+yl = ylims()
 for simulation in trajectories(sim)
-    plot!(fig, simulation, vars=(1, 2))
+    for piece in simulation
+        plot!(fig, piece, vars=(1, 2), lab="")
+    end
 end
 plot!(fig, project(X₀, 1:2), lab="X₀")
+xlims!(xl)
+ylims!(yl)
 
 #-
 
 fig = plot(xlab="x₂", ylab="x₄")
 plot!(fig, safe_states, color=:white, linecolor=:black, lw=5.0)
+xl = xlims()
+yl = ylims()
 for simulation in trajectories(sim)
-    plot!(fig, simulation, vars=(2, 4))
+    for piece in simulation
+        plot!(fig, piece, vars=(2, 4), lab="")
+    end
 end
 plot!(fig, project(X₀, [2, 4]), lab="X₀")
+xlims!(xl)
+ylims!(yl)
 
 #-
 
 fig = plot(xlab="x₂", ylab="x₃")
 plot!(fig, safe_states, color=:white, linecolor=:black, lw=5.0)
+xl = xlims()
+yl = ylims()
 for simulation in trajectories(sim)
-    plot!(fig, simulation, vars=(2, 3))
+    for piece in simulation
+        plot!(fig, piece, vars=(2, 3), lab="")
+    end
 end
 plot!(fig, project(X₀, [2, 3]), lab="X₀")
+xlims!(xl)
+ylims!(yl)
 
 #-
 


### PR DESCRIPTION
I did a mistake in #108: The struct did _not_ wrap a single simulation as intended but rather the results for one control cycle. I think it is more reasonable to instead store everything related to a single simulation in a `SimulationSolution`. (And some of the functions were not exported.)

Since there is currently no plot recipe for the `SimulationSolution` (#110), `plot` adds a new label for each trajectory now and plotting the simulation pieces recenters the picture. The second commit fixes these issues in the (currently only) model script that plots simulations.