### PR TITLE
Add Boxsolver

### DIFF
--- a/src/NeuralNetworkAnalysis.jl
+++ b/src/NeuralNetworkAnalysis.jl
@@ -13,7 +13,7 @@ export ControlledPlant
 
 # solvers
 export solve, forward, simulate,
-       VertexSolver
+       SampledApprox, VertexSolver, BoxSolver
 
 # utility functions
 export @modelpath, read_nnet_mat, read_nnet_yaml

--- a/src/nnops.jl
+++ b/src/nnops.jl
@@ -9,11 +9,9 @@ using NeuralVerification: @with_kw,
 # ================================================
 
 # output of neural network for a single input
-function forward(network::Network, x0::Vector{<:Number})
-    layers = network.layers
+function forward(nnet::Network, x0::Vector{<:Number})
     x = x0
-    @inbounds for i in 1:length(layers)
-        layer = network.layers[i]
+    @inbounds for layer in nnet.layers
         W = layer.weights
         b = layer.bias
         x = layer.activation(W * x + b)
@@ -21,9 +19,9 @@ function forward(network::Network, x0::Vector{<:Number})
     return x
 end
 
-# ==========================================================
-# Methods to handle networks with ReLU activation functions
-# ==========================================================
+# ============================================================================
+# Methods to approximate the network output (without mathematical guarantees)
+# ============================================================================
 
 # solver that propagates the vertices, computes their convex hull, and applies
 # some postprocessing to the result


### PR DESCRIPTION
EDIT: fixed in https://github.com/JuliaReach/ReachabilityAnalysis.jl/pull/463

---

I also observed a strange plotting issue (independent of these changes). It seems that the plot recipe adds a vertex from the previous polygon. I think this is new :open_mouth:

```julia
using NeuralNetworkAnalysis

controller = read_nnet(@modelpath("Single-Pendulum", "controller_single_pendulum.nnet"));

const m = 0.5;
const L = 0.5;
const c = 0.0;
const g = 1.0;
const gL = g/L;
const mL = 1/(m*L^2);

function single_pendulum!(dx, x, params, t)
    dx[1] = x[2]
    dx[2] = gL * sin(x[1]) + mL*(x[3] - c*x[2])
    dx[3] = zero(x[1]) # T = x[3]
    return dx
end

X0 = Hyperrectangle([1.1, 0.1], [0.1, 0.1]);
U0 = ZeroSet(1);
ivp = @ivp(x' = single_pendulum!(x), dim: 3, x(0) ∈ X0 × U0);
vars_idx = Dict(:state_vars=>1:2, :control_vars=>3);
period = 0.05;
T = 0.2;

prob = ControlledPlant(ivp, controller, vars_idx, period);
alg = TMJets(abs_tol=1e-10, orderT=10, orderQ=3);

alg_nn = Ai2();
@time sol1 = NeuralNetworkAnalysis.solve(prob, T=T, alg_nn=alg_nn, alg=alg);
solz1 = overapproximate(sol1, Zonotope);

alg_nn = BoxSolver();
@time sol2 = NeuralNetworkAnalysis.solve(prob, T=T, alg_nn=alg_nn, alg=alg);
solz2 = overapproximate(sol2, Zonotope);


using Plots
vars = (0, 1)
plot(solz1, vars=vars, lab="AI²")
plot!(solz2, vars=vars, lab="Box")
```

![pendulum](https://user-images.githubusercontent.com/9656686/115986418-5abb8d00-a5b0-11eb-954b-2a785b98f9b0.png)
