### PR TITLE
Helper function to print result of timed

### DIFF
--- a/src/NeuralNetworkAnalysis.jl
+++ b/src/NeuralNetworkAnalysis.jl
@@ -20,6 +20,6 @@ export solve, forward, simulate,
        SampledApprox, VertexSolver, BoxSolver, SplitSolver, BlackBoxSolver
 
 # utility functions
-export @modelpath, read_nnet_mat, read_nnet_yaml
+export @modelpath, read_nnet_mat, read_nnet_yaml, print_timed
 
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -276,3 +276,9 @@ function relative_size(X0, nsamples, controller, solver=Ai2())
     u = forward_network(SampledApprox(nsamples), controller, X0)
     return diameter(o)/diameter(u)
 end
+
+# print the result `@timed`
+function print_timed(stats::NamedTuple)
+    Base.time_print(stats.time * 1e9, stats.bytes, stats.gctime * 1e9,
+                    Base.gc_alloc_count(stats.gcstats), 0, true)
+end


### PR DESCRIPTION
This is useful for benchmarking if you do not want to print the results immediately.
It is used like this:
```julia
julia> X = @timed sleep(0.2);

julia> print_timed(X)
  0.201434 seconds (5 allocations: 144 bytes)

```