### PR TITLE
Change reference style

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,7 @@ jobs:
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(name="NeuralVerification", url="https://github.com/sisl/NeuralVerification.jl")); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
+          GKSwstype: nul  # Fix for Plots with GR backend
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
         run: julia --project=docs/ docs/make.jl

--- a/models/Cart-Pole/Cart-Pole.jl
+++ b/models/Cart-Pole/Cart-Pole.jl
@@ -75,8 +75,8 @@ controller = read_nnet_mat(path, key="controller")
 
 # ## References
 
-# [^BSA83]: A. G. Barto, R. S. Sutton, and C. W. Anderson. *Neuronlike adaptive
-#           elements that can solve difficult learning control problems.*
-#           [IEEE Transactions on Systems, Man, and Cybernetics, SMC-13(5):834–846,
-#           Sep. 1983](https://ieeexplore.ieee.org/abstract/document/6313077).
+# [BSA83]: A. G. Barto, R. S. Sutton, and C. W. Anderson. *Neuronlike adaptive
+#          elements that can solve difficult learning control problems.*
+#          [IEEE Transactions on Systems, Man, and Cybernetics, SMC-13(5):834–846,
+#          Sep. 1983](https://ieeexplore.ieee.org/abstract/document/6313077).
 #

--- a/models/Sherlock-Benchmark-10-Unicycle/Sherlock-Benchmark-10-Unicycle.jl
+++ b/models/Sherlock-Benchmark-10-Unicycle/Sherlock-Benchmark-10-Unicycle.jl
@@ -7,7 +7,7 @@ module Unicycle  #jl
 using NeuralNetworkAnalysis
 using NeuralNetworkAnalysis: UniformAdditivePostprocessing, SingleEntryVector
 
-# This benchmark is that of a unicycle model of a car [^1] taken from Benchmark
+# This benchmark is that of a unicycle model of a car [1] taken from Benchmark
 # 10 of the Sherlock tool. It models the dynamics of a car involving 4
 # variables, specifically the $x$ and $y$ coordinates on a 2 dimensional
 # plane, as well as velocity magnitude (speed) and steering angle.
@@ -192,7 +192,7 @@ fig = DisplayAs.Text(DisplayAs.PNG(fig))
 
 # ## References
 
-# [^1] Souradeep Dutta, Xin Chen, and Sriram Sankaranarayanan. *Reachability
+# [1] Souradeep Dutta, Xin Chen, and Sriram Sankaranarayanan. *Reachability
 # analysis for neural feedback systems using regressive polynomial rule
 # inference.* In [Proceedings of the 22nd ACMInternational Conference on Hybrid
 # Systems: Computation and Control, HSCC 2019, Montreal,QC, Canada,

--- a/models/Sherlock-Benchmark-7/Sherlock-Benchmark-7.jl
+++ b/models/Sherlock-Benchmark-7/Sherlock-Benchmark-7.jl
@@ -2,7 +2,7 @@
 #
 #md # [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/models/Sherlock-Benchmark-7.ipynb)
 #
-# The model was first proposed in [^YH12], where the authors originally designed a
+# The model was first proposed in [YH12], where the authors originally designed a
 # discontinuous sliding mode controller for this system.
 
 # ## Model
@@ -54,7 +54,7 @@ prob = @ivp(x' = f!(x), dim: 5, x(0) ∈ X₀ × W₀ × U₀);
 
 # ## References
 
-# [^YH12]: Dong-Hae Yeom and Young Hoon Joo. [*Control Lyapunov function design by
-#          cancelling input singularity.*](http://www.koreascience.or.kr/article/JAKO201220962918909.page).
-#          International Journal of Fuzzy Logic and Intelligent Systems, 12, 06 2012.
+# [YH12]: Dong-Hae Yeom and Young Hoon Joo. [*Control Lyapunov function design by
+#         cancelling input singularity.*](http://www.koreascience.or.kr/article/JAKO201220962918909.page).
+#         International Journal of Fuzzy Logic and Intelligent Systems, 12, 06 2012.
 #


### PR DESCRIPTION
`Documenter` renders `[^X]` as a small footnote that cannot be clicked.