### PR TITLE
#248 - Simplify specification sets

### DIFF
--- a/models/Sherlock-Benchmark-9-TORA/Sherlock-Benchmark-9-TORA.jl
+++ b/models/Sherlock-Benchmark-9-TORA/Sherlock-Benchmark-9-TORA.jl
@@ -5,8 +5,7 @@
 module TORA  #jl
 
 using NeuralNetworkAnalysis, MAT
-using NeuralNetworkAnalysis: UniformAdditivePostprocessing, SingleEntryVector,
-                             NoSplitter
+using NeuralNetworkAnalysis: UniformAdditivePostprocessing, NoSplitter
 
 # The following option determines whether the verification settings should be
 # used or not. The verification settings are chosen to show that the safety
@@ -71,19 +70,12 @@ control_postprocessing = UniformAdditivePostprocessing(-10.0)  # control postpro
 prob = ControlledPlant(ivp, controller, vars_idx, period;
                        postprocessing=control_postprocessing)
 
-## Safety specification
+## Safety specification: x[1], x[2], x[3], x[4] ∈ [-2, 2] for all t ≤ T
 T = 20.0  # time horizon
 T_warmup = 2 * period  # shorter time horizon for dry run
 T_reach = verification ? T : T_warmup  # shorter time horizon if not verifying
 
-safe_states = HPolyhedron([HalfSpace(SingleEntryVector(1, 5, 1.0), 2.0),
-                           HalfSpace(SingleEntryVector(1, 5, -1.0), 2.0),
-                           HalfSpace(SingleEntryVector(2, 5, 1.0), 2.0),
-                           HalfSpace(SingleEntryVector(2, 5, -1.0), 2.0),
-                           HalfSpace(SingleEntryVector(3, 5, 1.0), 2.0),
-                           HalfSpace(SingleEntryVector(3, 5, -1.0), 2.0),
-                           HalfSpace(SingleEntryVector(4, 5, 1.0), 2.0),
-                           HalfSpace(SingleEntryVector(4, 5, -1.0), 2.0)])
+safe_states = cartesian_product(BallInf(zeros(4), 2.0), Universe(1))
 predicate = X -> X ⊆ safe_states;
 
 # ## Results

--- a/models/Single-Pendulum/Single-Pendulum.jl
+++ b/models/Single-Pendulum/Single-Pendulum.jl
@@ -13,7 +13,7 @@ using NeuralNetworkAnalysis: SingleEntryVector
 
 # The following option determines whether the falsification settings should be
 # used or not. The falsification settings are sufficient to show that the safety
-# property is violated. Concretely we start from an initial point and use a
+# property is violated. Concretely, we start from an initial point and use a
 # smaller time step.
 const falsification = true;
 


### PR DESCRIPTION
Closes #248.

This required a new method in `LazySets` if `Polyhedra` were not loaded (but it is loaded by `NeuralVerification`).