### PR TITLE
Deactivate multi-threading

### DIFF
--- a/src/ClosedLoopReachability.jl
+++ b/src/ClosedLoopReachability.jl
@@ -1,5 +1,9 @@
 module ClosedLoopReachability
 
+# flag to (de)activate parallelism
+# deactivated by default because the GLPK solver is not thread-safe
+const PARALLEL = false
+
 include("init.jl")
 include("problem.jl")
 include("setops.jl")

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -159,7 +159,7 @@ function _solve(cp::ControlledPlant,
                                       reconstruction_method, algorithm_controller, controller,
                                       preprocessing, postprocessing, input_splitter)
     # parallelize analysis of the remaining parts
-    Threads.@threads for i in 2:length(results)
+    @cthreads PARALLEL for i in 2:length(results)
         @inbounds results[i] = _solve_one(R, X₀s[i], W₀, S, t0, t1, algorithm_plant,
                                           reconstruction_method, algorithm_controller, controller,
                                           preprocessing, postprocessing, input_splitter)
@@ -187,7 +187,7 @@ function _solve(cp::ControlledPlant,
         X₀s = haskey(splitter, k) ? apply(splitter[k], X₀) : [X₀]
         results = Vector{Vector{Flowpipe}}(undef, length(X₀s))
         # parallelize analysis
-        Threads.@threads for i in eachindex(results)
+        @cthreads PARALLEL for i in eachindex(results)
             @inbounds results[i] = _solve_one(R, X₀s[i], W₀, S, t0, t1, algorithm_plant,
                                               reconstruction_method, algorithm_controller,
                                               controller, preprocessing, postprocessing,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -88,3 +88,14 @@ function random_control_problems(n::Integer, m::Integer; ivp=nothing, period=0.1
 
     return problems
 end
+
+# source: https://discourse.julialang.org/t/conditional-multithreading/32421/12
+macro cthreads(flag, expr)
+    quote
+        if $(flag)
+            Threads.@threads $expr
+        else
+            $expr
+        end
+    end |> esc
+end


### PR DESCRIPTION
With multi-threading, VSCode crashes for me. This PR deactivates multi-threading, but it can be manually activated. This is only relevant when using an `AbstractSplitter`.